### PR TITLE
undefined obj should return undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = prop;
 
 function prop(obj, path, value) {
-  if (obj === null) return undefined;
+  if (!obj) return undefined;
   
   var isGet = arguments.length === 2;
 

--- a/test.js
+++ b/test.js
@@ -8,6 +8,20 @@ test('non-object', function(t) {
   t.equal(prop(false, ['a']), undefined);
 });
 
+test('null object', function(t) {
+  t.plan(3);
+  t.equal(prop(null, 'a'), undefined);
+  t.equal(prop(null, '/a'), undefined);
+  t.equal(prop(null, ['a']), undefined);
+});
+
+test('undefined object', function(t) {
+  t.plan(3);
+  t.equal(prop(undefined, 'a'), undefined);
+  t.equal(prop(undefined, '/a'), undefined);
+  t.equal(prop(undefined, ['a']), undefined);
+});
+
 test('empty object', function (t) {  
     t.plan(5);
 


### PR DESCRIPTION
When passing undefined as the first parameter we get a runtime exception. 
It should return undefined in that case.
